### PR TITLE
feat: Add GCS signed URL update utility

### DIFF
--- a/utilities/gcs-signed-urls-for-firestore/gcs-url-updater-service/Dockerfile
+++ b/utilities/gcs-signed-urls-for-firestore/gcs-url-updater-service/Dockerfile
@@ -1,0 +1,18 @@
+# Use an official, lightweight Python 3.9 image as a base
+FROM python:3.9-slim
+
+# Set the working directory inside the container to /app
+WORKDIR /app
+
+# Copy the requirements file into the container at /app
+COPY requirements.txt .
+
+# Install the Python dependencies
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the rest of the application's code into the container at /app
+COPY . .
+
+# Set the command to run the application using Gunicorn, a production-grade server.
+# It will listen on the port provided by the PORT environment variable, which Cloud Run sets automatically.
+CMD exec gunicorn --bind :$PORT --workers 1 --threads 8 --timeout 0 main:app

--- a/utilities/gcs-signed-urls-for-firestore/gcs-url-updater-service/README.md
+++ b/utilities/gcs-signed-urls-for-firestore/gcs-url-updater-service/README.md
@@ -1,8 +1,8 @@
 GCS Signed URL Refresh Utility
 Overview
-This utility was created to demonstrate how archival media content can be surfaced securely for Agentspace agents and other users to reference, along with its corresponding metadata from Firestore.
+This utility was created to demonstrate how archival media and news content can be surfaced securely for Agentspace agents and other users to reference, along with its corresponding metadata from Firestore. The no-code agents from agentspace would use the metadata to answer questions from archival data as its more cost effective but these signed urls would provide a link to users to reference the files. Anyone with access to the firestore metadata collection using the agent would have access to these signed_urls so its recommended to manage the user level access to firestore collection to ensure only authorised users can access the archival data. For production, more well defined security plan might need to be incorporated.
 
-It solves the problem of expiring Google Cloud Storage (GCS) signed URLs, which have a maximum lifespan of 7 days. This service provides a secure, on-demand, authenticated endpoint that, when triggered, will:
+This utility solves the problem of expiring Google Cloud Storage (GCS) signed URLs, which have a maximum lifespan of 7 days. This service provides a secure, on-demand, authenticated endpoint that, when triggered, will:
 
 Scan all objects in a specified GCS bucket.
 

--- a/utilities/gcs-signed-urls-for-firestore/gcs-url-updater-service/README.md
+++ b/utilities/gcs-signed-urls-for-firestore/gcs-url-updater-service/README.md
@@ -1,0 +1,104 @@
+GCS Signed URL Refresh Utility
+Overview
+This utility was created to demonstrate how archival media content can be surfaced securely for Agentspace agents and other users to reference, along with its corresponding metadata from Firestore.
+
+It solves the problem of expiring Google Cloud Storage (GCS) signed URLs, which have a maximum lifespan of 7 days. This service provides a secure, on-demand, authenticated endpoint that, when triggered, will:
+
+Scan all objects in a specified GCS bucket.
+
+Query a specified Firestore collection to find documents where the file_name field matches the GCS object name.
+
+Generate a new, 7-day signed URL for each matching object.
+
+Update the corresponding Firestore document with the new signed_url, url_expires_at, and last_url_update fields.
+
+How it Works
+This utility follows a secure, serverless architecture that relies on a dedicated Service Account and the Google Cloud IAM API for authentication.
+
+Authentication: Signing without a Key
+This service does not use a static private key (key.json) file in production. It leverages the Cloud Run environment's attached service account and its IAM permissions.
+
+When the service needs to sign a URL, it:
+
+Loads its own service account credentials from the environment (google.auth.default()).
+
+Refreshes these credentials to get a short-lived OAuth access_token.
+
+Passes this access_token and the service_account_email to the generate_signed_url function.
+
+This method securely delegates the cryptographic signing operation to the IAM API, which requires the service account to have the Service Account Token Creator role.
+
+Workflow
+An authorized user (e.g., an admin) sends an authenticated HTTP POST request to the service's URL.
+
+Cloud Run activates the service, which runs as its dedicated Service Account (gcs-url-updater-sa).
+
+The Python app starts. It first queries all documents in the Firestore collection and builds an in-memory map of {'file_name': doc_reference}. This is highly efficient and avoids querying Firestore inside a loop.
+
+The service then lists all objects in the GCS bucket.
+
+For each object, it looks up its name in the pre-built map.
+
+If a match is found, it generates a new signed URL using the IAM delegation method described above.
+
+It adds the update to a Firestore batch.
+
+After iterating through all objects, it commits the batch, updating all documents in a single atomic transaction.
+
+Configuration
+Configuration is handled by setting the variables in the Configuration section at the top of the deploy.sh script.
+
+The script will then pass these values as environment variables to the Cloud Run service, specifically:
+
+GCS_BUCKET
+
+FIRESTORE_COLLECTION
+
+SERVICE_ACCOUNT_EMAIL
+
+Deployment
+The service is deployed using a single shell script that handles all aspects of setup and deployment.
+
+Set Configuration: Edit the variables in the Configuration section at the top of deploy.sh (e.g., PROJECT_ID, GCS_BUCKET, FIRESTORE_COLLECTION).
+
+Make Executable: Ensure the script is executable:
+
+chmod +x deploy.sh
+
+Run Deploy: Run the script from within its folder:
+
+./deploy.sh
+
+The script will automatically:
+
+Enable all required Google Cloud APIs.
+
+Create the dedicated service account (gcs-url-updater-sa).
+
+Grant all necessary IAM permissions to the service account (storage.objectViewer, datastore.user, iam.serviceAccountTokenCreator).
+
+Grant all necessary permissions to the Cloud Build service (run.admin, iam.serviceAccountUser, etc.).
+
+Build the container image and deploy it to Cloud Run with the correct environment variables.
+
+How to Refresh Signed URLs (Usage)
+The service is triggered by sending an authenticated HTTP POST request to the service's main URL. No request body or JSON payload is required, as the service processes all objects in the bucket.
+
+1. Get Your Service URL
+You can find the URL in the output of the deployment script or by running this command:
+
+gcloud run services describe gcs-url-updater --platform=managed --region=us-central1 --format="value(status.url)"
+
+(Note: Replace us-central1 if you used a different region in your deploy.sh script.)
+
+2. Run the curl Command
+This command will automatically fetch your service's URL, get a valid authentication token for your gcloud user, and send the required POST request to trigger the refresh.
+
+curl -X POST "$(gcloud run services describe gcs-url-updater --platform=managed --region=us-central1 --format="value(status.url)")" \
+-H "Authorization: Bearer $(gcloud auth print-identity-token)"
+
+3. Monitor the Update
+The curl command will return a success message from the service, for example:
+Process complete. Successfully updated 123 documents. Skipped 4 objects.
+
+You can monitor the detailed, real-time progress by opening the Logs tab for the gcs-url-updater service in the Google Cloud Run console.

--- a/utilities/gcs-signed-urls-for-firestore/gcs-url-updater-service/deploy.sh
+++ b/utilities/gcs-signed-urls-for-firestore/gcs-url-updater-service/deploy.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+# --- Configuration ---
+# Set your project and service details here.
+PROJECT_ID="ENTER YOUR PROJECT ID HERE"
+REGION="ENTER YOUR REGION HERE"
+GCS_BUCKET="ENTER YOUR BUCKET NAME WITH FILES HERE"
+FIRESTORE_COLLECTION="ENTER YOUR FIRESTORE COLLECTION NAME HERE"
+SERVICE_NAME="gcs-url-updater"
+APP_SERVICE_ACCOUNT_NAME="gcs-url-updater-sa"
+# --- End of Configuration ---
+
+# --- Internal Script Variables (Do not change) ---
+APP_SERVICE_ACCOUNT_EMAIL="${APP_SERVICE_ACCOUNT_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
+
+# --- Script Starts Here ---
+
+echo "--- Step 1: Configuring gcloud to use project ${PROJECT_ID} ---"
+gcloud config set project ${PROJECT_ID}
+
+echo -e "\n--- Step 2: Enabling required Google Cloud APIs ---"
+gcloud services enable run.googleapis.com iam.googleapis.com cloudbuild.googleapis.com artifactregistry.googleapis.com firestore.googleapis.com storage.googleapis.com
+
+# --- Create the application's own service account ---
+echo -e "\n--- Step 3: Creating a dedicated Service Account for the App ---"
+if gcloud iam service-accounts describe ${APP_SERVICE_ACCOUNT_EMAIL} > /dev/null 2>&1; then
+    echo "Service Account [${APP_SERVICE_ACCOUNT_NAME}] already exists. Skipping creation."
+else
+    echo "Creating Service Account [${APP_SERVICE_ACCOUNT_NAME}]."
+    gcloud iam service-accounts create ${APP_SERVICE_ACCOUNT_NAME} --display-name="Service Account for GCS URL Updater"
+    echo "Waiting for 10 seconds for IAM propagation..."
+    sleep 10
+fi
+
+# --- Grant permissions to the application's service account ---
+echo -e "\n--- Step 4: Granting permissions to the App's Service Account (so it can run correctly) ---"
+gcloud projects add-iam-policy-binding ${PROJECT_ID} --member="serviceAccount:${APP_SERVICE_ACCOUNT_EMAIL}" --role="roles/storage.objectViewer" --condition=None >/dev/null
+gcloud projects add-iam-policy-binding ${PROJECT_ID} --member="serviceAccount:${APP_SERVICE_ACCOUNT_EMAIL}" --role="roles/datastore.user" --condition=None >/dev/null
+gcloud iam service-accounts add-iam-policy-binding ${APP_SERVICE_ACCOUNT_EMAIL} --member="serviceAccount:${APP_SERVICE_ACCOUNT_EMAIL}" --role="roles/iam.serviceAccountTokenCreator" >/dev/null
+
+# --- Grant permissions to the Cloud Build service ---
+echo -e "\n--- Step 5: Granting permissions to the Cloud Build Service (so it can deploy) ---"
+PROJECT_NUMBER=$(gcloud projects describe ${PROJECT_ID} --format="value(projectNumber)")
+CLOUD_BUILD_SERVICE_ACCOUNT="${PROJECT_NUMBER}@cloudbuild.gserviceaccount.com"
+gcloud projects add-iam-policy-binding ${PROJECT_ID} --member="serviceAccount:${CLOUD_BUILD_SERVICE_ACCOUNT}" --role="roles/run.admin" --condition=None >/dev/null
+gcloud projects add-iam-policy-binding ${PROJECT_ID} --member="serviceAccount:${CLOUD_BUILD_SERVICE_ACCOUNT}" --role="roles/iam.serviceAccountUser" --condition=None >/dev/null
+gcloud projects add-iam-policy-binding ${PROJECT_ID} --member="serviceAccount:${CLOUD_BUILD_SERVICE_ACCOUNT}" --role="roles/artifactregistry.writer" --condition=None >/dev/null
+gcloud projects add-iam-policy-binding ${PROJECT_ID} --member="serviceAccount:${CLOUD_BUILD_SERVICE_ACCOUNT}" --role="roles/logging.logWriter" --condition=None >/dev/null
+echo "Permissions check complete."
+
+
+# --- Build and Deploy the service ---
+echo -e "\n--- Step 6: Building and deploying the service to Cloud Run ---"
+# This single command handles build and deploy. It is the most reliable method.
+# It correctly passes all three environment variables to the service.
+gcloud run deploy ${SERVICE_NAME} \
+  --source . \
+  --platform=managed \
+  --region=${REGION} \
+  --service-account=${APP_SERVICE_ACCOUNT_EMAIL} \
+  --set-env-vars="GCS_BUCKET=${GCS_BUCKET},FIRESTORE_COLLECTION=${FIRESTORE_COLLECTION},SERVICE_ACCOUNT_EMAIL=${APP_SERVICE_ACCOUNT_EMAIL}" \
+  --no-allow-unauthenticated
+
+# --- Final Output ---
+if [ $? -eq 0 ]; then
+  echo -e "\n--- ✅ Deployment Complete! ---"
+  SERVICE_URL=$(gcloud run services describe ${SERVICE_NAME} --platform=managed --region=${REGION} --format="value(status.url)")
+  echo "Service Name: ${SERVICE_NAME}"
+  echo "Service URL: ${SERVICE_URL}"
+else
+    echo -e "\n--- ❌ Deployment Failed ---"
+    echo "Please check the error messages above."
+fi

--- a/utilities/gcs-signed-urls-for-firestore/gcs-url-updater-service/main.py
+++ b/utilities/gcs-signed-urls-for-firestore/gcs-url-updater-service/main.py
@@ -50,7 +50,7 @@ def update_all_signed_urls_in_bucket():
         for blob in all_blobs:
             object_name = blob.name
             try:
-                # Use the in-memory map for a fast lookup
+                # Using the in-memory map for a fast lookup
                 if object_name not in docs_by_filename:
                     skipped_count += 1
                     continue

--- a/utilities/gcs-signed-urls-for-firestore/gcs-url-updater-service/main.py
+++ b/utilities/gcs-signed-urls-for-firestore/gcs-url-updater-service/main.py
@@ -1,0 +1,99 @@
+import os
+import datetime
+from flask import Flask, request
+import google.auth
+import google.auth.transport.requests
+from google.cloud import firestore
+from google.cloud import storage
+
+app = Flask(__name__)
+db = firestore.Client()
+storage_client = storage.Client()
+
+GCS_BUCKET_NAME = os.environ.get("GCS_BUCKET")
+FIRESTORE_COLLECTION = os.environ.get("FIRESTORE_COLLECTION")
+SERVICE_ACCOUNT_EMAIL = os.environ.get("SERVICE_ACCOUNT_EMAIL")
+
+if not GCS_BUCKET_NAME or not FIRESTORE_COLLECTION or not SERVICE_ACCOUNT_EMAIL:
+    raise RuntimeError("Configuration error: GCS_BUCKET, FIRESTORE_COLLECTION, and SERVICE_ACCOUNT_EMAIL environment variables must be set.")
+
+@app.route("/", methods=["POST"])
+def update_all_signed_urls_in_bucket():
+    
+    try:
+        credentials, project = google.auth.default()
+
+        # When running on Cloud Run, the default credentials do not have a private
+        # key. To sign a URL, we must use the IAM signBlob API, which requires an
+        # OAuth2 access token. We refresh the credentials to get a current token.
+        auth_request = google.auth.transport.requests.Request()
+        credentials.refresh(auth_request)
+
+        bucket = storage_client.bucket(GCS_BUCKET_NAME)
+        all_blobs = bucket.list_blobs()
+        
+        print("Building an index of Firestore documents by 'file_name'...")
+        docs_by_filename = {}
+        for doc in db.collection(FIRESTORE_COLLECTION).stream():
+            doc_data = doc.to_dict()
+            # Ensure the document has the 'file_name' field before adding to the map
+            if 'file_name' in doc_data:
+                docs_by_filename[doc_data['file_name']] = doc.reference
+        print(f"Index built. Found {len(docs_by_filename)} documents with a 'file_name' field.")
+
+        batch = db.batch()
+        updated_count = 0
+        skipped_count = 0
+        
+        expiration_delta = datetime.timedelta(days=7)
+
+        for blob in all_blobs:
+            object_name = blob.name
+            try:
+                # Use the in-memory map for a fast lookup
+                if object_name not in docs_by_filename:
+                    skipped_count += 1
+                    continue
+
+                doc_ref = docs_by_filename[object_name]
+                
+                expiration_datetime = datetime.datetime.now(datetime.timezone.utc) + expiration_delta
+                
+                # To sign a URL without a private key, we must delegate the signing
+                # to the service account itself using the IAM API. This is done by
+                # providing the service account's email and a valid access token.
+                signed_url = blob.generate_signed_url(
+                    version="v4",
+                    expiration=expiration_datetime,
+                    method="GET",
+                    service_account_email=SERVICE_ACCOUNT_EMAIL,
+                    access_token=credentials.token,
+                )
+                
+                update_data = {
+                    'signed_url': signed_url,
+                    'url_expires_at': expiration_datetime,
+                    'last_url_update': firestore.SERVER_TIMESTAMP
+                }
+                
+                batch.set(doc_ref, update_data, merge=True)
+                updated_count += 1
+
+            except Exception as e:
+                print(f"An error occurred while processing {object_name}: {e}")
+                skipped_count += 1
+        
+        batch.commit()
+        
+        success_message = f"Process complete. Successfully updated {updated_count} documents. Skipped {skipped_count} objects."
+        print(success_message)
+        return success_message, 200
+
+    except Exception as e:
+        error_msg = f"An unexpected error occurred: {e}"
+        print(error_msg)
+        return error_msg, 500
+
+if __name__ == "__main__":
+    PORT = int(os.environ.get("PORT", 8080))
+    app.run(host="0.0.0.0", port=PORT, debug=True)

--- a/utilities/gcs-signed-urls-for-firestore/gcs-url-updater-service/requirements.txt
+++ b/utilities/gcs-signed-urls-for-firestore/gcs-url-updater-service/requirements.txt
@@ -1,0 +1,4 @@
+Flask==2.3.3
+gunicorn==21.2.0
+google-cloud-storage==2.11.0
+google-cloud-firestore==2.11.1


### PR DESCRIPTION
Created a utility folder
Added the utility which creates signed-urls of the assets in cloud storage and stores the signed_urls in firestore. The utility uses the "file_name" field from existing firestore collection to find the files in bucket for which it need to update the signed urls.

